### PR TITLE
fix(path_generator): fix path bound generation for overlapped lanes (…

### DIFF
--- a/planning/autoware_path_generator/include/autoware/path_generator/utils.hpp
+++ b/planning/autoware_path_generator/include/autoware/path_generator/utils.hpp
@@ -113,41 +113,68 @@ std::vector<std::pair<lanelet::ConstPoints3d, std::pair<double, double>>> get_wa
   const double group_separation_threshold, const double interval_margin_ratio);
 
 /**
- * @brief get position of first self-intersection (point where return
- * path intersects outward path) of lanelet sequence in arc length
- * @param lanelet_sequence target lanelet sequence (both left and right bound are
- * considered)
- * @param s_start longitudinal distance of point to start searching for self-intersections
+ * @brief get position of first intersection (including self-intersection) in lanelet sequence in
+ * arc length
+ * @param lanelet_sequence target lanelet sequence
+ * @param s_start longitudinal distance of point to start searching for intersections
  * @param s_end longitudinal distance of point to end search
+ * @param vehicle_length vehicle length
+ * @return longitudinal distance of intersecting point (std::nullopt if no intersection)
+ */
+std::optional<double> get_first_intersection_arc_length(
+  const lanelet::LaneletSequence & lanelet_sequence, const double s_start, const double s_end,
+  const double vehicle_length);
+
+/**
+ * @brief get position of first self-intersection (point where return
+ * path intersects outward path) of line string in arc length
+ * @param line_string target line string
  * @return longitudinal distance of self-intersecting point (std::nullopt if no
  * self-intersection)
  */
 std::optional<double> get_first_self_intersection_arc_length(
+  const lanelet::BasicLineString2d & line_string);
+
+/**
+ * @brief get path bounds for PathWithLaneId cropped within specified range
+ * @param lanelet_sequence lanelet sequence
+ * @param s_start longitudinal distance of start of bound on centerline
+ * @param s_end longitudinal distance of end of bound on centerline
+ * @return cropped bounds (left / right)
+ */
+std::array<std::vector<geometry_msgs::msg::Point>, 2> get_path_bounds(
   const lanelet::LaneletSequence & lanelet_sequence, const double s_start, const double s_end);
 
 /**
- * @brief get position of first self-intersection of line string in arc length
- * @param line_string target line string
- * @param s_start longitudinal distance of point to start searching for self-intersections
- * @param s_end longitudinal distance of point to end search
- * @return longitudinal distance of self-intersecting point (std::nullopt if no
- * self-intersection)
+ * @brief crop line string
+ * @param line_string line string
+ * @param s_start longitudinal distance to crop from
+ * @param s_end longitudinal distance to crop to
+ * @return cropped line string
  */
-std::optional<double> get_first_self_intersection_arc_length(
-  const lanelet::BasicLineString2d & line_string, const double s_start, const double s_end);
+std::vector<geometry_msgs::msg::Point> crop_line_string(
+  const std::vector<geometry_msgs::msg::Point> & line_string, const double s_start,
+  const double s_end);
 
 /**
- * @brief get path bound for PathWithLaneId cropped within specified range
- * @param lanelet_bound original bound of lanelet
- * @param lanelet_centerline centerline of lanelet
- * @param s_start longitudinal distance of start of bound
- * @param s_end longitudinal distance of end of bound
- * @return cropped bound
+ * @brief get positions of given point on centerline projected to left / right bound in arc length
+ * @param lanelet_sequence lanelet sequence
+ * @param s_centerline longitudinal distance of point on centerline
+ * @return longitudinal distance of projected point (left / right)
  */
-std::vector<geometry_msgs::msg::Point> get_path_bound(
-  const lanelet::CompoundLineString3d & lanelet_bound,
-  const lanelet::CompoundLineString2d & lanelet_centerline, const double s_start,
-  const double s_end);
+std::array<double, 2> get_arc_length_on_bounds(
+  const lanelet::LaneletSequence & lanelet_sequence, const double s_centerline);
+
+/**
+ * @brief get positions of given point on left / right bound projected to centerline in arc length
+ * @param lanelet_sequence lanelet sequence
+ * @param s_left_bound longitudinal distance of point on left bound
+ * @param s_right_bound longitudinal distance of point on left bound
+ * @return longitudinal distance of projected point (left / right)
+ */
+std::array<std::optional<double>, 2> get_arc_length_on_centerline(
+  const lanelet::LaneletSequence & lanelet_sequence, const std::optional<double> & s_left_bound,
+  const std::optional<double> & s_right_bound);
 
 /**
  * @brief Recreate the goal pose to prevent the goal point being too far from the lanelet, which

--- a/planning/autoware_path_generator/src/utils.cpp
+++ b/planning/autoware_path_generator/src/utils.cpp
@@ -44,6 +44,29 @@ bool exists(const std::vector<T> & vec, const T & item)
 {
   return std::find(vec.begin(), vec.end(), item) != vec.end();
 }
+
+template <typename const_iterator>
+std::vector<geometry_msgs::msg::Point> to_geometry_msgs_points(
+  const const_iterator begin, const const_iterator end)
+{
+  std::vector<geometry_msgs::msg::Point> geometry_msgs_points{};
+  geometry_msgs_points.reserve(std::distance(begin, end));
+  std::transform(begin, end, std::back_inserter(geometry_msgs_points), [](const auto & point) {
+    return lanelet::utils::conversion::toGeomMsgPt(point);
+  });
+  return geometry_msgs_points;
+}
+
+lanelet::BasicPoints3d to_lanelet_points(
+  const std::vector<geometry_msgs::msg::Point> & geometry_msgs_points)
+{
+  lanelet::BasicPoints3d lanelet_points{};
+  lanelet_points.reserve(geometry_msgs_points.size());
+  std::transform(
+    geometry_msgs_points.begin(), geometry_msgs_points.end(), std::back_inserter(lanelet_points),
+    [](const auto & point) { return lanelet::utils::conversion::toLaneletPoint(point); });
+  return lanelet_points;
+}
 }  // namespace
 
 std::optional<lanelet::ConstLanelets> get_lanelets_within_route(
@@ -176,50 +199,6 @@ std::optional<lanelet::ConstLanelet> get_next_lanelet_within_route(
   return *next_lanelet_itr;
 }
 
-std::optional<double> get_first_self_intersection_arc_length(
-  const lanelet::LaneletSequence & lanelet_sequence, const double s_start, const double s_end)
-{
-  const auto s_left = get_first_self_intersection_arc_length(
-    lanelet_sequence.leftBound2d().basicLineString(), s_start, s_end);
-  const auto s_right = get_first_self_intersection_arc_length(
-    lanelet_sequence.rightBound2d().basicLineString(), s_start, s_end);
-
-  if (s_left && s_right) {
-    return std::min(*s_left, *s_right);
-  }
-  return s_left ? s_left : s_right;
-}
-
-std::optional<double> get_first_self_intersection_arc_length(
-  const lanelet::BasicLineString2d & line_string, const double s_start, const double s_end)
-{
-  const auto tree = lanelet::geometry::internal::makeIndexedSegmenTree(line_string);
-  std::optional<std::pair<size_t, double>> last_intersection = std::nullopt;
-  auto s = 0.;
-
-  for (size_t i = 1; i < line_string.size() - 1; ++i) {
-    if (last_intersection && i == last_intersection->first) {
-      return s + last_intersection->second;
-    }
-    s += lanelet::geometry::distance2d(line_string.at(i - 1), line_string.at(i));
-    if (s < s_start) {
-      continue;
-    }
-    if (s > s_end) {
-      break;
-    }
-    const auto self_intersections = lanelet::geometry::internal::getSelfIntersectionsAt(
-      tree, 0, lanelet::BasicSegment2d{line_string.at(i - 1), line_string.at(i)});
-    if (self_intersections.empty()) {
-      continue;
-    }
-    last_intersection = {
-      self_intersections.front().lastSegment.idx, self_intersections.front().lastSegment.s};
-  }
-
-  return std::nullopt;
-}
-
 std::vector<std::pair<lanelet::ConstPoints3d, std::pair<double, double>>> get_waypoint_groups(
   const lanelet::LaneletSequence & lanelet_sequence, const lanelet::LaneletMap & lanelet_map,
   const double group_separation_threshold, const double interval_margin_ratio)
@@ -258,47 +237,320 @@ std::vector<std::pair<lanelet::ConstPoints3d, std::pair<double, double>>> get_wa
   return waypoint_groups;
 }
 
-std::vector<geometry_msgs::msg::Point> get_path_bound(
-  const lanelet::CompoundLineString3d & lanelet_bound,
-  const lanelet::CompoundLineString2d & lanelet_centerline, const double s_start,
-  const double s_end)
+std::optional<double> get_first_intersection_arc_length(
+  const lanelet::LaneletSequence & lanelet_sequence, const double s_start, const double s_end,
+  const double vehicle_length)
 {
-  const auto lanelet_bound_2d = lanelet::utils::to2D(lanelet_bound);
-  const auto s_bound_start =
-    lanelet::geometry::toArcCoordinates(
-      lanelet_bound_2d, lanelet::geometry::interpolatedPointAtDistance(lanelet_centerline, s_start))
-      .length;
-  const auto s_bound_end =
-    lanelet::geometry::toArcCoordinates(
-      lanelet_bound_2d, lanelet::geometry::interpolatedPointAtDistance(lanelet_centerline, s_end))
-      .length;
+  std::optional<double> s_intersection{std::nullopt};
 
-  std::vector<geometry_msgs::msg::Point> path_bound{};
-  auto s = 0.;
+  const auto s_start_bounds = get_arc_length_on_bounds(lanelet_sequence, s_start);
+  const double s_start_left_bound = s_start_bounds.at(0);
+  const double s_start_right_bound = s_start_bounds.at(1);
 
-  for (auto it = lanelet_bound.begin(); it != std::prev(lanelet_bound.end()); ++it) {
-    s += lanelet::geometry::distance2d(*it, *std::next(it));
-    if (s < s_bound_start) {
-      continue;
-    }
+  const auto s_end_bound = get_arc_length_on_bounds(lanelet_sequence, s_end);
+  const double s_end_left_bound = s_end_bound.at(0);
+  const double s_end_right_bound = s_end_bound.at(1);
 
-    if (path_bound.empty()) {
-      const auto interpolated_point =
-        lanelet::geometry::interpolatedPointAtDistance(lanelet_bound, s_bound_start);
-      path_bound.push_back(lanelet::utils::conversion::toGeomMsgPt(interpolated_point));
+  const auto cropped_centerline = lanelet::utils::to2D(to_lanelet_points(crop_line_string(
+    to_geometry_msgs_points(
+      lanelet_sequence.centerline2d().begin(), lanelet_sequence.centerline2d().end()),
+    s_start, s_end)));
+  const auto cropped_left_bound = lanelet::utils::to2D(to_lanelet_points(crop_line_string(
+    to_geometry_msgs_points(
+      lanelet_sequence.leftBound2d().begin(), lanelet_sequence.leftBound2d().end()),
+    s_start_left_bound, s_end_left_bound)));
+  const auto cropped_right_bound = lanelet::utils::to2D(to_lanelet_points(crop_line_string(
+    to_geometry_msgs_points(
+      lanelet_sequence.rightBound2d().begin(), lanelet_sequence.rightBound2d().end()),
+    s_start_right_bound, s_end_right_bound)));
+
+  const lanelet::BasicLineString2d start_edge{
+    cropped_left_bound.front(), cropped_right_bound.front()};
+
+  // self intersection
+  {
+    const auto s_left_bound = [&]() {
+      auto s = get_first_self_intersection_arc_length(cropped_left_bound);
+      if (s) {
+        *s += s_start_left_bound;
+      }
+      return s;
+    }();
+    const auto s_right_bound = [&]() {
+      auto s = get_first_self_intersection_arc_length(cropped_right_bound);
+      if (s) {
+        *s += s_start_right_bound;
+      }
+      return s;
+    }();
+
+    const auto s_bounds_on_centerline =
+      get_arc_length_on_centerline(lanelet_sequence, s_left_bound, s_right_bound);
+    const auto s_left = s_bounds_on_centerline.at(0);
+    const auto s_right = s_bounds_on_centerline.at(1);
+
+    if (s_left && s_right) {
+      s_intersection = std::min(s_left, s_right);
     } else {
-      path_bound.push_back(lanelet::utils::conversion::toGeomMsgPt(*it));
-    }
-
-    if (s >= s_bound_end) {
-      const auto interpolated_point =
-        lanelet::geometry::interpolatedPointAtDistance(lanelet_bound, s_bound_end);
-      path_bound.push_back(lanelet::utils::conversion::toGeomMsgPt(interpolated_point));
-      break;
+      s_intersection = s_left ? s_left : s_right;
     }
   }
 
-  return path_bound;
+  // intersection between left and right bounds
+  {
+    lanelet::BasicPoints2d intersections;
+    boost::geometry::intersection(cropped_left_bound, cropped_right_bound, intersections);
+    for (const auto & intersection : intersections) {
+      const auto s_bounds_on_centerline = get_arc_length_on_centerline(
+        lanelet_sequence,
+        s_start_left_bound +
+          lanelet::geometry::toArcCoordinates(cropped_left_bound, intersection).length,
+        s_start_right_bound +
+          lanelet::geometry::toArcCoordinates(cropped_right_bound, intersection).length);
+      const auto s_left = s_bounds_on_centerline.at(0);
+      const auto s_right = s_bounds_on_centerline.at(1);
+      const auto s_mutual = [&]() {
+        if (s_left && s_right) {
+          return std::max(s_left, s_right);
+        }
+        return s_left ? s_left : s_right;
+      }();
+      if (s_intersection && s_mutual) {
+        s_intersection = std::min(s_intersection, s_mutual);
+      } else if (s_mutual) {
+        s_intersection = s_mutual;
+      }
+    }
+  }
+
+  // intersection between start edge of drivable area and left / right bound
+  {
+    const auto get_start_edge_intersection_arc_length =
+      [&](const lanelet::BasicLineString2d & bound) {
+        std::optional<double> s_start_edge = std::nullopt;
+        if (bound.size() <= 2) {
+          return s_start_edge;
+        }
+        lanelet::BasicPoints2d start_edge_intersections;
+        boost::geometry::intersection(start_edge, bound, start_edge_intersections);
+        for (const auto & intersection : start_edge_intersections) {
+          if (boost::geometry::equals(intersection, bound.front())) {
+            continue;
+          }
+          const auto s = lanelet::geometry::toArcCoordinates(bound, intersection).length;
+          s_start_edge = s_start_edge ? std::min(*s_start_edge, s) : s;
+        }
+        return s_start_edge;
+      };
+    const auto s_left_bound = [&]() {
+      auto s = get_start_edge_intersection_arc_length(cropped_left_bound);
+      if (s) {
+        *s += s_start_left_bound;
+      }
+      return s;
+    }();
+    const auto s_right_bound = [&]() {
+      auto s = get_start_edge_intersection_arc_length(cropped_right_bound);
+      if (s) {
+        *s += s_start_right_bound;
+      }
+      return s;
+    }();
+
+    const auto s_bounds_on_centerline =
+      get_arc_length_on_centerline(lanelet_sequence, s_left_bound, s_right_bound);
+    const auto s_left = s_bounds_on_centerline.at(0);
+    const auto s_right = s_bounds_on_centerline.at(1);
+
+    const auto s_start_edge = [&]() {
+      if (s_left && s_right) {
+        return std::min(s_left, s_right);
+      }
+      return s_left ? s_left : s_right;
+    }();
+    if (s_intersection && s_start_edge) {
+      s_intersection = std::min(s_intersection, s_start_edge);
+    } else if (s_start_edge) {
+      s_intersection = s_start_edge;
+    }
+  }
+
+  // intersection between start edge of drivable area and center line
+  {
+    std::optional<double> s_start_edge = std::nullopt;
+    lanelet::BasicPoints2d start_edge_intersections;
+    boost::geometry::intersection(start_edge, cropped_centerline, start_edge_intersections);
+    for (const auto & intersection : start_edge_intersections) {
+      auto s = lanelet::geometry::toArcCoordinates(cropped_centerline, intersection).length;
+      // Ignore intersections near the beginning of the centerline.
+      // It is impossible to make a turn shorter than the vehicle_length, so use it as a threshold.
+      if (s < vehicle_length) continue;
+      s += s_start;
+      s_start_edge = s_start_edge ? std::min(*s_start_edge, s) : s;
+    }
+    if (s_intersection && s_start_edge) {
+      s_intersection = std::min(s_intersection, s_start_edge);
+    } else if (s_start_edge) {
+      s_intersection = s_start_edge;
+    }
+  }
+
+  return s_intersection;
+}
+
+std::optional<double> get_first_self_intersection_arc_length(
+  const lanelet::BasicLineString2d & line_string)
+{
+  if (line_string.size() < 3) {
+    return std::nullopt;
+  }
+
+  const auto tree = lanelet::geometry::internal::makeIndexedSegmenTree(line_string);
+  std::optional<lanelet::geometry::internal::SelfIntersectionLong> first_self_intersection_long =
+    std::nullopt;
+  double s = 0.;
+
+  for (size_t i = 1; i < line_string.size() - 1; ++i) {
+    if (first_self_intersection_long && i == first_self_intersection_long->idx + 1) {
+      return s + first_self_intersection_long->s;
+    }
+    s += lanelet::geometry::distance2d(line_string.at(i - 1), line_string.at(i));
+    const auto self_intersections = lanelet::geometry::internal::getSelfIntersectionsAt(
+      tree, 0, lanelet::BasicSegment2d{line_string.at(i - 1), line_string.at(i)});
+    if (self_intersections.empty()) {
+      continue;
+    }
+    first_self_intersection_long = self_intersections.front().lastSegment;
+  }
+
+  return std::nullopt;
+}
+
+std::array<std::vector<geometry_msgs::msg::Point>, 2> get_path_bounds(
+  const lanelet::LaneletSequence & lanelet_sequence, const double s_start, const double s_end)
+{
+  const auto [s_left_start, s_right_start] = get_arc_length_on_bounds(lanelet_sequence, s_start);
+  const auto [s_left_end, s_right_end] = get_arc_length_on_bounds(lanelet_sequence, s_end);
+
+  return {
+    crop_line_string(
+      to_geometry_msgs_points(
+        lanelet_sequence.leftBound().begin(), lanelet_sequence.leftBound().end()),
+      s_left_start, s_left_end),
+    crop_line_string(
+      to_geometry_msgs_points(
+        lanelet_sequence.rightBound().begin(), lanelet_sequence.rightBound().end()),
+      s_right_start, s_right_end)};
+}
+
+std::vector<geometry_msgs::msg::Point> crop_line_string(
+  const std::vector<geometry_msgs::msg::Point> & line_string, const double s_start,
+  const double s_end)
+{
+  // TODO(mitukou1109): use autoware_trajectory
+  const auto lanelet_line_string = to_lanelet_points(line_string);
+  std::vector<geometry_msgs::msg::Point> cropped_line_string;
+  auto s = 0.;
+
+  for (auto it = std::next(lanelet_line_string.begin()); it != lanelet_line_string.end(); ++it) {
+    const lanelet::BasicLineString3d segment{*std::prev(it), *it};
+    const auto segment_length = lanelet::geometry::length(segment);
+    if (s <= s_start) {
+      if (s + segment_length < s_start) {
+        s += segment_length;
+        continue;
+      }
+      cropped_line_string.push_back(lanelet::utils::conversion::toGeomMsgPt(
+        lanelet::geometry::interpolatedPointAtDistance(segment, s_start - s)));
+    }
+    s += segment_length;
+    if (s >= s_end) {
+      cropped_line_string.push_back(lanelet::utils::conversion::toGeomMsgPt(
+        lanelet::geometry::interpolatedPointAtDistance(segment, s_end - s)));
+      break;
+    }
+    cropped_line_string.push_back(lanelet::utils::conversion::toGeomMsgPt(*it));
+  }
+
+  return cropped_line_string;
+}
+
+std::array<double, 2> get_arc_length_on_bounds(
+  const lanelet::LaneletSequence & lanelet_sequence, const double s_centerline)
+{
+  auto s = 0.;
+  auto s_left = 0.;
+  auto s_right = 0.;
+
+  for (auto it = lanelet_sequence.begin(); it != lanelet_sequence.end(); ++it) {
+    const double centerline_length = lanelet::geometry::length(it->centerline2d());
+    const double left_bound_length = lanelet::geometry::length(it->leftBound2d());
+    const double right_bound_length = lanelet::geometry::length(it->rightBound2d());
+
+    if (s + centerline_length < s_centerline) {
+      s += centerline_length;
+      s_left += left_bound_length;
+      s_right += right_bound_length;
+      continue;
+    }
+
+    const auto point_on_centerline =
+      lanelet::geometry::interpolatedPointAtDistance(it->centerline2d(), s_centerline - s);
+    s_left += lanelet::geometry::toArcCoordinates(it->leftBound2d(), point_on_centerline).length;
+    s_right += lanelet::geometry::toArcCoordinates(it->rightBound2d(), point_on_centerline).length;
+
+    return {s_left, s_right};
+  }
+
+  // If the loop ends without returning, it means that the lanelet_sequence is too short.
+  // In this case, we return the original arc length on the centerline.
+  return {s_centerline, s_centerline};
+}
+
+std::array<std::optional<double>, 2> get_arc_length_on_centerline(
+  const lanelet::LaneletSequence & lanelet_sequence, const std::optional<double> & s_left_bound,
+  const std::optional<double> & s_right_bound)
+{
+  std::optional<double> s_left_centerline = std::nullopt;
+  std::optional<double> s_right_centerline = std::nullopt;
+
+  auto s = 0.;
+  auto s_left = 0.;
+  auto s_right = 0.;
+
+  for (auto it = lanelet_sequence.begin(); it != lanelet_sequence.end(); ++it) {
+    const auto is_left_done = !s_left_bound || s_left_centerline;
+    const auto is_right_done = !s_right_bound || s_right_centerline;
+    if (is_left_done && is_right_done) {
+      break;
+    }
+
+    const double centerline_length = lanelet::utils::getLaneletLength2d(*it);
+    const double left_bound_length = lanelet::geometry::length(it->leftBound2d());
+    const double right_bound_length = lanelet::geometry::length(it->rightBound2d());
+
+    if (!is_left_done && s_left + left_bound_length > s_left_bound) {
+      s_left_centerline = s + lanelet::geometry::toArcCoordinates(
+                                it->centerline2d(), lanelet::geometry::interpolatedPointAtDistance(
+                                                      it->leftBound2d(), *s_left_bound - s_left))
+                                .length;
+    }
+    if (!is_right_done && s_right + right_bound_length > s_right_bound) {
+      s_right_centerline =
+        s + lanelet::geometry::toArcCoordinates(
+              it->centerline2d(), lanelet::geometry::interpolatedPointAtDistance(
+                                    it->rightBound2d(), *s_right_bound - s_right))
+              .length;
+    }
+
+    s += centerline_length;
+    s_left += left_bound_length;
+    s_right += right_bound_length;
+  }
+
+  return {
+    s_left_centerline ? s_left_centerline : s_left_bound,
+    s_right_centerline ? s_right_centerline : s_right_bound};
 }
 
 const geometry_msgs::msg::Pose refine_goal(


### PR DESCRIPTION
## Description

cherry-pick  https://github.com/autowarefoundation/autoware_core/pull/285

X1 v2025.3.0リリースのブロッキング課題への対応
https://tier4.atlassian.net/browse/RT0-35938
重複レーンにおけるdrivable areaを修正


## Related links

**Parent Issue:**

- https://star4.slack.com/archives/C07K1PPNPTR/p1742781217317799 Update Request

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

https://tier4.atlassian.net/browse/RT0-35938 のEvidenceに記載内容
- 無印main: psim, X1CommonBasic
- pilot-auto.x1 v2025.3.0 にcherry-pickしてX1CommonBasic　

このPR元のブランチではbuild確認のみです。

## Notes for reviewers

path_generatorはx1でのみ使用するノードです。デフォルト起動しないため、そのまま動作確認はできないです。私のテスト内容で十分で、ADREでの追加確認はなくて大丈夫かと思います。

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
